### PR TITLE
autoattack

### DIFF
--- a/Skua.Core.Models/Monsters/Monster.cs
+++ b/Skua.Core.Models/Monsters/Monster.cs
@@ -56,19 +56,8 @@ public class Monster
     /// <summary>
     /// Indicates if this monster is alive.
     /// </summary>
-    public bool Alive
-    {
-        get
-        {
-            return isKilled ? HP > 0 : true;
-        }
-        set
-        {
-            isKilled = true;
-        }
-    }
-
-    private bool isKilled = false;
+    
+    public bool Alive => HP > 0;
 
     public override string ToString()
     {

--- a/releases.json
+++ b/releases.json
@@ -63,7 +63,7 @@
         "content_type": "application/octet-stream",
         "state": "uploaded",
         "size": 20744911,
-        "download_count": 493,
+        "download_count": 518,
         "created_at": "2024-04-05T10:45:12Z",
         "updated_at": "2024-04-05T10:45:37Z",
         "browser_download_url": "https://github.com/BrenoHenrike/Skua/releases/download/1.2.4.0/Skua-1.2.4.0-Release-x64.msi"
@@ -97,7 +97,7 @@
         "content_type": "application/octet-stream",
         "state": "uploaded",
         "size": 20720341,
-        "download_count": 127,
+        "download_count": 141,
         "created_at": "2024-04-05T10:45:37Z",
         "updated_at": "2024-04-05T10:46:01Z",
         "browser_download_url": "https://github.com/BrenoHenrike/Skua/releases/download/1.2.4.0/Skua-1.2.4.0-Release-x86.msi"
@@ -2408,7 +2408,7 @@
         "content_type": "application/x-zip-compressed",
         "state": "uploaded",
         "size": 19016106,
-        "download_count": 23,
+        "download_count": 24,
         "created_at": "2022-07-30T21:43:16Z",
         "updated_at": "2022-07-30T21:43:19Z",
         "browser_download_url": "https://github.com/BrenoHenrike/Skua/releases/download/0.2.0.0/Skua-0.2.0.0-Release-x86.zip"

--- a/releases.json
+++ b/releases.json
@@ -63,7 +63,7 @@
         "content_type": "application/octet-stream",
         "state": "uploaded",
         "size": 20744911,
-        "download_count": 518,
+        "download_count": 520,
         "created_at": "2024-04-05T10:45:12Z",
         "updated_at": "2024-04-05T10:45:37Z",
         "browser_download_url": "https://github.com/BrenoHenrike/Skua/releases/download/1.2.4.0/Skua-1.2.4.0-Release-x64.msi"


### PR DESCRIPTION
The Alive property sometimes do not update based on the monster’s HP. As a result, the autoattack feature continues targeting dead monsters or there was a delay switching between monsters after kill.

The Alive property now directly checks if the monster’s HP is greater than zero to determine if the monster is dead or alive.

I was unable to build the program to try this code out.